### PR TITLE
use explicit css nesting selector

### DIFF
--- a/src/demo/components/card.js
+++ b/src/demo/components/card.js
@@ -36,13 +36,13 @@ export default class Card extends HTMLElement {
             background-color: #fff;
             overflow-x: hidden;
 
-            > img {
+            & img {
               max-width: 500px;
               min-width: 500px;
               width: 100%;
             }
             
-            > h3 {
+            & h3 {
               color: var(--color-primary);
               font-size: 1.85rem;
             }

--- a/src/demo/components/header.js
+++ b/src/demo/components/header.js
@@ -10,11 +10,11 @@ export default class Header extends HTMLElement {
           header {
             text-align: center;
 
-            > h1 {
+            & h1 {
               display: inline;
             }
 
-            > img {
+            & img {
               width: 25px;
             }
           }


### PR DESCRIPTION
It wasn't clear from [the article](https://developer.chrome.com/articles/css-nesting/) I read but usage of the _child_ CSS selector (`>`) is not specifically the new nesting syntax.  It seems based on some of the examples in this article

> _In this example, the `.child` [class selector](https://web.dev/learn/css/selectors#class_selector) is nested within the `.parent` class selector. This means that the nested .child selector will only apply to elements that are children of elements with a `.parent` class._
```css
.parent {
  color: blue;

  .child {
    color: red;
  }
}
```

The nesting can be implicit.  But to be explicit, the `&` should be used
> _This example could alternatively be written using the `&` symbol, to explicitly signify where the parent class should be placed._
```css
.parent {
  color: blue;

  & .child {
    color: red;
  }
}
```